### PR TITLE
Performance improvements to calculate item position

### DIFF
--- a/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
+++ b/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
@@ -42,9 +42,28 @@ class ADMozaikLayoutMatrix {
     /// Number of rows in the matrix
     fileprivate var numberOfRows: Int = 0
     
+    /// This is very important dictionary
+    /// It contains information of the last item with specific size position
+    /// E.x. the following items in the following order are added into the matrix
+    /// (columns: 1, rows 1) at (column: 0, row: 0)
+    /// (columns: 2, rows 2) at (column: 1, row: 0)
+    /// (columns: 1, rows 2) at (column: 0, row: 1)
+    /// (columns: 3, rows 3) at (column: 0, row: 3)
+    /// (columns: 1, rows 1) at (column: 1, row: 1)
+    /// Then the dictionary contains the following info:
+    /// [
+    ///  (columns: 1, rows 1): (column: 1, row: 1),
+    ///  (columns: 2, rows 2): (column: 1, row: 0),
+    ///  (columns: 1, rows 2): (column: 0, row: 1),
+    ///  (columns: 3, rows 3): (column: 0, row: 3)
+    /// ]
+    /// The general idea of it, that e.x. for item with size (columns: 1, rows 1), 
+    /// that we can not place it earlier that that position. So we can start iterating from that position
+    fileprivate var lastItemPositionOfSize: [ADMozaikLayoutSize: ADMozaikLayoutPosition]
+    
     /// Number of columns in the matrix
     fileprivate let numberOfColumns: Int
- 
+    
     //MARK: - Interface
     
     ///

--- a/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
+++ b/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
@@ -97,15 +97,24 @@ class ADMozaikLayoutMatrix {
         if maximumColumn < 0 {
             throw ADMozaikLayoutMatrixError.columnOutOfBounds
         }
-        
-        for row in 0...numberOfRows {
+        return self.positionForItem(of: size, startingFrom: 0, maximumPositionColumn: maximumColumn)
+    }
+    
+    //MARK: - Helpers
+    
+    fileprivate func positionForItem(of size: ADMozaikLayoutSize, startingFrom startRow: Int, maximumPositionColumn maximumColumn: Int) -> ADMozaikLayoutPosition {
+        for row in startRow...numberOfRows {
             for column in 0...maximumColumn {
                 let possiblePosition = ADMozaikLayoutPosition(atColumn: column, atRow: row)
                 var isPositionFree = false
                 do {
-                    try isPositionFree = self.isPositionFree(possiblePosition, forItemOf: size)
+                    isPositionFree = try self.isPositionFree(possiblePosition, forItemOf: size)
                 }
-                catch {
+                catch ADMozaikLayoutMatrixError.rowOutOfBounds {
+                    self.extendMatrix(by: size.rows)
+                    return self.positionForItem(of: size, startingFrom: row, maximumPositionColumn: maximumColumn)
+                }
+                catch  {
                     print(error)
                 }
                 if isPositionFree {
@@ -113,17 +122,8 @@ class ADMozaikLayoutMatrix {
                 }
             }
         }
-        self.extendMatrix(by: size.rows)
-        
-        do {
-            return try self.positionForItem(of: size)
-        }
-        catch {
-            fatalError((error as! CustomStringConvertible).description)
-        }
+        return ADMozaikLayoutPosition(atColumn: 0, atRow: 0)
     }
-    
-    //MARK: - Helpers
     
     fileprivate func extendMatrix(by rowsCount: Int) {
         for column in 0..<numberOfColumns {

--- a/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
+++ b/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutMatrix.swift
@@ -59,7 +59,7 @@ class ADMozaikLayoutMatrix {
     /// ]
     /// The general idea of it, that e.x. for item with size (columns: 1, rows 1), 
     /// that we can not place it earlier that that position. So we can start iterating from that position
-    fileprivate var lastItemPositionOfSize: [ADMozaikLayoutSize: ADMozaikLayoutPosition]
+    fileprivate var lastItemPositionOfSize: [ADMozaikLayoutSize: ADMozaikLayoutPosition] = [:]
     
     /// Number of columns in the matrix
     fileprivate let numberOfColumns: Int
@@ -100,6 +100,7 @@ class ADMozaikLayoutMatrix {
         for column in position.column...lastColumn {
             for row in position.row...lastRow {
                 arrayRepresentation[column][row] = true
+                lastItemPositionOfSize[size] = position
             }
         }
     }
@@ -116,7 +117,13 @@ class ADMozaikLayoutMatrix {
         if maximumColumn < 0 {
             throw ADMozaikLayoutMatrixError.columnOutOfBounds
         }
-        return self.positionForItem(of: size, startingFrom: 0, maximumPositionColumn: maximumColumn)
+        let latestPositionForItemOfSameSize: ADMozaikLayoutPosition? = lastItemPositionOfSize[size]
+        if let latestRowPositionForItemOfSameSize = latestPositionForItemOfSameSize?.row {
+            return self.positionForItem(of: size, startingFrom: latestRowPositionForItemOfSameSize, maximumPositionColumn: maximumColumn)
+        }
+        else {
+            return self.positionForItem(of: size, startingFrom: 0, maximumPositionColumn: maximumColumn)
+        }
     }
     
     //MARK: - Helpers

--- a/ADMozaikCollectionViewLayout/Public/ADMozaikLayoutStructs.swift
+++ b/ADMozaikCollectionViewLayout/Public/ADMozaikLayoutStructs.swift
@@ -8,14 +8,19 @@
 
 import Foundation
 
+public typealias ADMozaikLayoutPositionRow = Int
+public typealias ADMozaikLayoutPositionColumn = Int
+public typealias ADMozaikLayoutSizeRows = Int
+public typealias ADMozaikLayoutSizeColumns = Int
+
 /**
  *  Defines the structure to identify the position of the layout item
  */
-public struct ADMozaikLayoutPosition {
+public struct ADMozaikLayoutPosition: Hashable {
     /// Column number of the item's position
-    let column: Int
+    let column: ADMozaikLayoutPositionColumn
     /// Row number of the item's position
-    let row: Int
+    let row: ADMozaikLayoutPositionRow
     
     ///
     /// Designated initializer for structure
@@ -24,16 +29,26 @@ public struct ADMozaikLayoutPosition {
     /// - parameter row:    roe number
     ///
     /// - returns: newly created `ADMozaikLayoutPosition`
-    public init(atColumn column: Int, atRow row: Int) {
+    public init(atColumn column: ADMozaikLayoutPositionRow, atRow row: ADMozaikLayoutPositionColumn) {
         self.column = column
         self.row = row
+    }
+    
+    //MARK: - Hashable
+    
+    public var hashValue: Int {
+        return column.hashValue ^ row.hashValue
+    }
+    
+    public static func == (lhs: ADMozaikLayoutPosition, rhs: ADMozaikLayoutPosition) -> Bool {
+        return lhs.row == rhs.row && lhs.column == rhs.column
     }
 }
 
 /**
  *  Defines the size of the layout item
  */
-public struct ADMozaikLayoutSize {
+public struct ADMozaikLayoutSize: Hashable {
     /// Columns number that item requires
     let columns: Int
     /// Rows number that item requires
@@ -57,6 +72,16 @@ public struct ADMozaikLayoutSize {
     /// - returns: number of required mozaik cells for item
     public func totalCells() -> Int {
         return self.columns * self.rows
+    }
+
+    //MARK: - Hashable
+    
+    public var hashValue: Int {
+        return columns.hashValue ^ rows.hashValue
+    }
+    
+    public static func == (lhs: ADMozaikLayoutSize, rhs: ADMozaikLayoutSize) -> Bool {
+        return lhs.rows == rhs.rows && lhs.columns == rhs.columns
     }
 }
 

--- a/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutMatrixTests.swift
+++ b/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutMatrixTests.swift
@@ -71,4 +71,25 @@ class ADMozaikLayoutMatrixTests: XCTestCase {
         }
         catch { fatalError() }
     }
+    
+    func testPositionForItemPerformance() {
+        let sizesArray = [ADMozaikLayoutSize(numberOfColumns: 1, numberOfRows: 1),
+                          ADMozaikLayoutSize(numberOfColumns: 2, numberOfRows: 2),
+                          ADMozaikLayoutSize(numberOfColumns: 2, numberOfRows: 1),
+                          ADMozaikLayoutSize(numberOfColumns: 1, numberOfRows: 2),
+                          ADMozaikLayoutSize(numberOfColumns: 3, numberOfRows: 3),
+                          ADMozaikLayoutSize(numberOfColumns: 3, numberOfRows: 2),
+                          ADMozaikLayoutSize(numberOfColumns: 3, numberOfRows: 1),
+                          ADMozaikLayoutSize(numberOfColumns: 1, numberOfRows: 3)]
+        measure {
+            do {
+                for i in 0...200 {
+                    let size = sizesArray[i % 8]
+                    let position = try self.matrixLayout.positionForItem(of: size)
+                    try self.matrixLayout.addItem(of: size, at: position)
+                }
+            }
+            catch { fatalError() }
+        }
+    }
 }

--- a/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
+++ b/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
@@ -319,24 +319,5 @@ class ADMozaikLayoutTests: XCTestCase {
             return column1 == column2
         }))
     }
-    
-    func testPerformanceTestToPrepareLayout() {
-        class MockCollectionView: UICollectionView {
-            private override var numberOfSections: Int {
-                return 1
-            }
-            
-            private override func numberOfItems(inSection section: Int) -> Int {
-                return 10000
-            }
-        }
-        
-        let geometryInfo1 = ADMozaikLayoutGeometryInfo(rowHeight: 10, columns: [ADMozaikLayoutColumn(width: 10), ADMozaikLayoutColumn(width: 10), ADMozaikLayoutColumn(width: 10)])
-        let layout = ADMozaikLayout(geometryInfo: geometryInfo1, for: UIDeviceOrientation.portrait)
-        layout.minimumLineSpacing = 1
-        layout.minimumInteritemSpacing = 1
-        layout.collectionView = 
-        
-    }
 }
 

--- a/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
+++ b/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
@@ -319,5 +319,24 @@ class ADMozaikLayoutTests: XCTestCase {
             return column1 == column2
         }))
     }
+    
+    func testPerformanceTestToPrepareLayout() {
+        class MockCollectionView: UICollectionView {
+            private override var numberOfSections: Int {
+                return 1
+            }
+            
+            private override func numberOfItems(inSection section: Int) -> Int {
+                return 10000
+            }
+        }
+        
+        let geometryInfo1 = ADMozaikLayoutGeometryInfo(rowHeight: 10, columns: [ADMozaikLayoutColumn(width: 10), ADMozaikLayoutColumn(width: 10), ADMozaikLayoutColumn(width: 10)])
+        let layout = ADMozaikLayout(geometryInfo: geometryInfo1, for: UIDeviceOrientation.portrait)
+        layout.minimumLineSpacing = 1
+        layout.minimumInteritemSpacing = 1
+        layout.collectionView = 
+        
+    }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,7 +2,8 @@
 upcoming:
   version: 2.1.0
   notes:
-  - support different orientations for layout
+  - Support different orientations for layout
+  - Item position calculation performance win 💥
 releases:
 - version: 2.0.0
   notes:

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -85,7 +85,7 @@ class ViewController: UIViewController, ADMozaikLayoutDelegate, UICollectionView
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return 10000
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
This is a huge win for performance by caching the position of last placed item with the similar size.
This is addressed to #11 
