### PR TITLE
Fix the Xcode swift warning;

### DIFF
--- a/ADMozaikCollectionViewLayout.xcodeproj/project.pbxproj
+++ b/ADMozaikCollectionViewLayout.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Anton Domashnev";
 				TargetAttributes = {
 					6D7BE5B01CEA148400A41445 = {

--- a/ADMozaikCollectionViewLayout.xcodeproj/xcshareddata/xcschemes/ADMozaikCollectionViewLayout.xcscheme
+++ b/ADMozaikCollectionViewLayout.xcodeproj/xcshareddata/xcschemes/ADMozaikCollectionViewLayout.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutCache.swift
+++ b/ADMozaikCollectionViewLayout/Private/ADMozaikLayoutCache.swift
@@ -78,7 +78,7 @@ class ADMozaikLayoutCache {
     func mozaikSizeForItem(atIndexPath indexPath: IndexPath) -> ADMozaikLayoutSize {
         var size: ADMozaikLayoutSize? = self.cachedSizeOfItemAtIndexPathDictionary[indexPath]
         if size == nil {
-            size = self.mozaikLayoutDelegate.collectionView(self.collectionView, layout: self.collectionView.collectionViewLayout, mozaikSizeForItemAtIndexPath: indexPath)
+            size = self.mozaikLayoutDelegate.collectionView(self.collectionView, mozaik: self.collectionView.collectionViewLayout, mozaikSizeForItemAt: indexPath)
         }
         return size!
     }

--- a/ADMozaikCollectionViewLayout/Public/ADMozaikLayoutDelegate.swift
+++ b/ADMozaikCollectionViewLayout/Public/ADMozaikLayoutDelegate.swift
@@ -19,5 +19,5 @@ public protocol ADMozaikLayoutDelegate: UICollectionViewDelegateFlowLayout {
     /// - parameter indexPath:      indexPath of item for the size it asks for
     ///
     /// - returns: `ADMozaikLayoutSize` struct object describes the size
-    func collectionView(_ collectionView: UICollectionView, layout: UICollectionViewLayout, mozaikSizeForItemAtIndexPath indexPath: IndexPath) -> ADMozaikLayoutSize
+    func collectionView(_ collectionView: UICollectionView, mozaik layout: UICollectionViewLayout, mozaikSizeForItemAt indexPath: IndexPath) -> ADMozaikLayoutSize
 }

--- a/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutCacheTests.swift
+++ b/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutCacheTests.swift
@@ -25,7 +25,7 @@ private class ADMozaikLayoutCacheTestsCollectionView: UICollectionView {
 
 private class ADMozaikLayoutCacheTestsADMozaikLayoutDelegate: NSObject, ADMozaikLayoutDelegate {
     
-    fileprivate func collectionView(_ collectionView: UICollectionView, layout: UICollectionViewLayout, mozaikSizeForItemAtIndexPath indexPath: IndexPath) -> ADMozaikLayoutSize {
+    fileprivate func collectionView(_ collectionView: UICollectionView, mozaik layout: UICollectionViewLayout, mozaikSizeForItemAt indexPath: IndexPath) -> ADMozaikLayoutSize {
         return ADMozaikLayoutSize(numberOfColumns: (indexPath as NSIndexPath).section, numberOfRows: (indexPath as NSIndexPath).item)
     }
     

--- a/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
+++ b/ADMozaikCollectionViewLayoutTests/ADMozaikLayoutTests.swift
@@ -169,7 +169,7 @@ class ADMozaikLayoutTestsViewController: UIViewController, ADMozaikLayoutDelegat
     
     //MARK: - ADMozaikLayoutDelegate
     
-    func collectionView(_ collectionView: UICollectionView, layout: UICollectionViewLayout, mozaikSizeForItemAtIndexPath indexPath: IndexPath) -> ADMozaikLayoutSize {
+    func collectionView(_ collectionView: UICollectionView, mozaik layout: UICollectionViewLayout, mozaikSizeForItemAt indexPath: IndexPath) -> ADMozaikLayoutSize {
         switch self.useCase! {
         case .f:
             if (indexPath as NSIndexPath).item % 8 == 0 {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,10 +1,13 @@
 ---
 upcoming:
-  version: 2.1.0
+  version: 3.0.0
+  notes:
+  - incompatible renaming in ADMozaikLayoutDelegate to silence Xcode warning [#15](https://github.com/Antondomashnev/ADMozaicCollectionViewLayout/issues/15)
+releases:
+- version: 2.1.0
   notes:
   - Support different orientations for layout
   - Item position calculation performance win 💥
-releases:
 - version: 2.0.0
   notes:
   - Swift 3.0 compatibility

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -60,7 +60,7 @@ class ViewController: UIViewController, ADMozaikLayoutDelegate, UICollectionView
     
     //MARK: - ADMozaikLayoutDelegate
     
-    func collectionView(_ collectionView: UICollectionView, layout: UICollectionViewLayout, mozaikSizeForItemAtIndexPath indexPath: IndexPath) -> ADMozaikLayoutSize {
+    func collectionView(_ collectionView: UICollectionView, mozaik layout: UICollectionViewLayout, mozaikSizeForItemAt indexPath: IndexPath) -> ADMozaikLayoutSize {
         if indexPath.item == 0 {
             return ADMozaikLayoutSize(numberOfColumns: 1, numberOfRows: 1)
         }


### PR DESCRIPTION
The PR is addressing the issue #15, unfortunately the best way in my opinion to fix the warning was to rename the `ADMozaikLayoutDelegate` method which brought incompatibility with the previous version and marking the method as deprecated requires the `@objc` keyword, which I don't see the point to introduce.